### PR TITLE
WIP LineBotアーキテクチャ化　Feature/add api

### DIFF
--- a/cmd/botapi/main.go
+++ b/cmd/botapi/main.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure"
-	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/api"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/db"
+	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/line"
 )
 
 func main() {
-	bot, err := api.NewLineHandller()
+	bot, err := line.NewLineClient()
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/cmd/botapi/main.go
+++ b/cmd/botapi/main.go
@@ -4,14 +4,19 @@ import (
 	"fmt"
 
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure"
+	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/api"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/db"
 )
 
 func main() {
+	bot, err := api.NewLineHandller()
+	if err != nil {
+		fmt.Println(err)
+	}
 	db, err := db.NewHandler()
 	if err != nil {
 		fmt.Println(err)
 	}
-	infrastructure.NewServer(db)
+	infrastructure.NewServer(db, bot)
 
 }

--- a/cmd/botapi/main.go
+++ b/cmd/botapi/main.go
@@ -11,10 +11,7 @@ func main() {
 	db, err := db.NewHandler()
 	if err != nil {
 		fmt.Println(err)
-		return
-	} else {
-		fmt.Println(db)
 	}
-
 	infrastructure.NewServer(db)
+
 }

--- a/cmd/botapi/main.go
+++ b/cmd/botapi/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	bot, err := line.NewLineClient()
+	bot, err := line.NewClient()
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -5,3 +5,7 @@ type Schedule struct {
 	Day      string
 	Contents string
 }
+
+type ApiValue struct {
+	VALUE string
+}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.18
 require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/lib/pq v1.10.7 // indirect
+	github.com/line/line-bot-sdk-go v7.8.0+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/line/line-bot-sdk-go v7.8.0+incompatible h1:Uf9/OxV0zCVfqyvwZPH8CrdiHXXmMRa/L91G3btQblQ=
+github.com/line/line-bot-sdk-go v7.8.0+incompatible/go.mod h1:0RjLjJEAU/3GIcHkC3av6O4jInAbt25nnZVmOFUgDBg=

--- a/interfaces/common_interractor.go
+++ b/interfaces/common_interractor.go
@@ -8,4 +8,5 @@ import (
 
 type CommonInteractor interface {
 	UseCaseSampleRepository(context.Context) ([]*domain.Schedule, error)
+	UseCaseLineRepository(ctx context.Context)
 }

--- a/interfaces/common_interractor.go
+++ b/interfaces/common_interractor.go
@@ -8,5 +8,5 @@ import (
 
 type CommonInteractor interface {
 	UseCaseSampleRepository(context.Context) ([]*domain.Schedule, error)
-	UseCaseLineRepository(ctx context.Context)
+	// UseCaseLineRepository(ctx context.Context)
 }

--- a/interfaces/common_interractor.go
+++ b/interfaces/common_interractor.go
@@ -2,11 +2,9 @@ package interfaces
 
 import (
 	"context"
-
-	"github.com/tmkshy1908/Portfolio/domain"
 )
 
 type CommonInteractor interface {
-	UseCaseSampleRepository(context.Context) ([]*domain.Schedule, error)
+	DivideMessage(context.Context)
 	// UseCaseLineRepository(ctx context.Context)
 }

--- a/interfaces/contoller.go
+++ b/interfaces/contoller.go
@@ -43,7 +43,6 @@ func (cc *CommonController) Sayhello(w http.ResponseWriter, r *http.Request) {
 func (cc *CommonController) SampleHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
-	// ctx = context.WithValue(ctx, "request", r)
 
 	resp, err := cc.Interactor.UseCaseSampleRepository(ctx)
 	if err != nil {

--- a/interfaces/contoller.go
+++ b/interfaces/contoller.go
@@ -46,6 +46,6 @@ func (cc *CommonController) SampleHandler(w http.ResponseWriter, r *http.Request
 		fmt.Println(err)
 		return
 	}
-
+	fmt.Println("SampleHandler")
 	fmt.Println(resp)
 }

--- a/interfaces/contoller.go
+++ b/interfaces/contoller.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/api"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/db"
 	"github.com/tmkshy1908/Portfolio/usecase"
 )
@@ -18,14 +19,16 @@ type CommonController struct {
 type Controller interface {
 	Sayhello(http.ResponseWriter, *http.Request)
 	SampleHandler(http.ResponseWriter, *http.Request)
+	LineHandller(http.ResponseWriter, *http.Request)
 }
 
-func NewController(SqlHandler db.SqlHandler) (cc *CommonController) {
+func NewController(SqlHandler db.SqlHandler, LineHandller api.LineHandller) (cc *CommonController) {
 	// UseCase interface 構造体の値の初期化
 	cc = &CommonController{
 		Interactor: &usecase.CommonInteractor{
 			CommonRepository: &CommonRepository{
-				DB: SqlHandler,
+				DB:  SqlHandler,
+				Bot: LineHandller,
 			},
 		},
 	}
@@ -48,4 +51,12 @@ func (cc *CommonController) SampleHandler(w http.ResponseWriter, r *http.Request
 	}
 	fmt.Println("SampleHandler")
 	fmt.Println(resp)
+}
+
+func (cc *CommonController) LineHandller(w http.ResponseWriter, r *http.Request) {
+	fmt.Println("LineHandller")
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	ctx = context.WithValue(ctx, "request", r)
+	cc.Interactor.UseCaseLineRepository(ctx)
 }

--- a/interfaces/contoller.go
+++ b/interfaces/contoller.go
@@ -12,7 +12,7 @@ import (
 )
 
 type CommonController struct {
-	controller Controller
+	// controller Controller
 	Interactor CommonInteractor
 }
 
@@ -39,15 +39,7 @@ func (cc *CommonController) Sayhello(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hello")
 }
 
-func (cc *CommonController) SampleHandler(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
-	defer cancel()
-
-	cc.Interactor.DivideMessage(ctx)
-}
-
 func (cc *CommonController) LineHandller(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("LineHandller")
 	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	ctx = context.WithValue(ctx, "request", r)

--- a/interfaces/contoller.go
+++ b/interfaces/contoller.go
@@ -43,6 +43,7 @@ func (cc *CommonController) Sayhello(w http.ResponseWriter, r *http.Request) {
 func (cc *CommonController) SampleHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
+	// ctx = context.WithValue(ctx, "request", r)
 
 	resp, err := cc.Interactor.UseCaseSampleRepository(ctx)
 	if err != nil {
@@ -58,5 +59,5 @@ func (cc *CommonController) LineHandller(w http.ResponseWriter, r *http.Request)
 	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	ctx = context.WithValue(ctx, "request", r)
-	cc.Interactor.UseCaseLineRepository(ctx)
+	cc.Interactor.UseCaseSampleRepository(ctx)
 }

--- a/interfaces/contoller.go
+++ b/interfaces/contoller.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/api"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/db"
+	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/line"
 	"github.com/tmkshy1908/Portfolio/usecase"
 )
 
@@ -22,7 +22,7 @@ type Controller interface {
 	LineHandller(http.ResponseWriter, *http.Request)
 }
 
-func NewController(SqlHandler db.SqlHandler, LineHandller api.LineHandller) (cc *CommonController) {
+func NewController(SqlHandler db.SqlHandler, LineHandller line.LineClient) (cc *CommonController) {
 	// UseCase interface 構造体の値の初期化
 	cc = &CommonController{
 		Interactor: &usecase.CommonInteractor{
@@ -37,20 +37,13 @@ func NewController(SqlHandler db.SqlHandler, LineHandller api.LineHandller) (cc 
 
 func (cc *CommonController) Sayhello(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hello")
-	fmt.Println("SayhelloName")
 }
 
 func (cc *CommonController) SampleHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
-	resp, err := cc.Interactor.UseCaseSampleRepository(ctx)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	fmt.Println("SampleHandler")
-	fmt.Println(resp)
+	cc.Interactor.DivideMessage(ctx)
 }
 
 func (cc *CommonController) LineHandller(w http.ResponseWriter, r *http.Request) {
@@ -58,5 +51,5 @@ func (cc *CommonController) LineHandller(w http.ResponseWriter, r *http.Request)
 	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	ctx = context.WithValue(ctx, "request", r)
-	cc.Interactor.UseCaseSampleRepository(ctx)
+	cc.Interactor.DivideMessage(ctx)
 }

--- a/interfaces/repository.go
+++ b/interfaces/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/line/line-bot-sdk-go/linebot"
 	"github.com/tmkshy1908/Portfolio/domain"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/api"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/db"
@@ -44,6 +45,21 @@ func (r *CommonRepository) Find(ctx context.Context) (schedule []*domain.Schedul
 	return
 }
 
-func (r *CommonRepository) Inform(ctx context.Context) {
-	r.Bot.CathEvents(ctx)
+func (r *CommonRepository) DivideEvent(ctx context.Context) {
+	event := r.Bot.CathEvents(ctx)
+	fmt.Println(event)
+	if event.Type == linebot.EventTypeMessage {
+		switch Message := event.Message.(type) {
+		case *linebot.TextMessage:
+			msg := Message.Text
+			r.Bot.CallBack(msg)
+		}
+	} else {
+		fmt.Println("だめです")
+	}
+}
+
+func (r *CommonRepository) ConversionReply(resp []*domain.Schedule) {
+	// 文字列に直す処理
+	// r.Bot.MsgReply(resp)
 }

--- a/interfaces/repository.go
+++ b/interfaces/repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	// "github.com/line/line-bot-sdk-go/linebot"
 	"github.com/tmkshy1908/Portfolio/domain"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/api"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/db"
@@ -51,8 +50,3 @@ func (r *CommonRepository) DivideEvent(ctx context.Context) (msg string) {
 
 	return
 }
-
-// func (r *CommonRepository) ConversionReply(resp []*domain.Schedule) {
-// 	// 文字列に直す処理
-// 	// r.Bot.MsgReply(resp)
-// }

--- a/interfaces/repository.go
+++ b/interfaces/repository.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/line/line-bot-sdk-go/linebot"
+	// "github.com/line/line-bot-sdk-go/linebot"
 	"github.com/tmkshy1908/Portfolio/domain"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/api"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/db"
@@ -45,9 +45,9 @@ func (r *CommonRepository) Find(ctx context.Context) (schedule []*domain.Schedul
 	return
 }
 
-func (r *CommonRepository) DivideEvent(ctx context.Context) (e *linebot.Event) {
-	event := r.Bot.CathEvents(ctx)
-	fmt.Println("DivideEvent", event)
+func (r *CommonRepository) DivideEvent(ctx context.Context) (msg string) {
+	msg = r.Bot.CathEvents(ctx)
+	fmt.Println("DivideEvent", msg)
 
 	return
 }

--- a/interfaces/repository.go
+++ b/interfaces/repository.go
@@ -44,6 +44,14 @@ func (r *CommonRepository) Find(ctx context.Context) (schedule []*domain.Schedul
 	return
 }
 
+// func (r *CommonRepository) add(ctx context.Context) {
+// 	_, err := r.DB.Exec(ctx, INSERT_SCHEDULE)
+// 	if err != nil {
+// 		fmt.Println(err)
+// 		return
+// 	}
+// }
+
 func (r *CommonRepository) DivideEvent(ctx context.Context) (msg string) {
 	msg = r.Bot.CathEvents(ctx)
 	fmt.Println("DivideEvent", msg)

--- a/interfaces/repository.go
+++ b/interfaces/repository.go
@@ -46,9 +46,7 @@ func (r *CommonRepository) Find(ctx context.Context) (schedule []*domain.Schedul
 }
 
 func (r *CommonRepository) DivideEvent(ctx context.Context) (e *linebot.Event) {
-	fmt.Println("DivideEve")
 	event := r.Bot.CathEvents(ctx)
-	// r.Bot.Hoge(event) エラ〜起きる
 	fmt.Println("DivideEvent", event)
 
 	return

--- a/interfaces/repository.go
+++ b/interfaces/repository.go
@@ -50,3 +50,7 @@ func (r *CommonRepository) DivideEvent(ctx context.Context) (msg string) {
 
 	return
 }
+
+func (r *CommonRepository) CallReply(msg string) {
+	r.Bot.MsgReply(msg)
+}

--- a/interfaces/repository.go
+++ b/interfaces/repository.go
@@ -14,6 +14,7 @@ type CommonRepository struct {
 
 const (
 	SELECT_SCHEDULE string = "select id, day, contents from schedule;"
+	INSERT_SCHEDULE string = "insert into schedule (id, day, contents) values($1,$2,$3)"
 )
 
 func (r *CommonRepository) Find(ctx context.Context) (schedule []*domain.Schedule, err error) {
@@ -40,3 +41,12 @@ func (r *CommonRepository) Find(ctx context.Context) (schedule []*domain.Schedul
 	}
 	return
 }
+
+// func (r *CommonRepository) Create(ctx context.Context) (schedule []*domain.Schedule, err error){
+// 	_, err = r.DB.Exec(ctx, INSERT_SCHEDULE)
+// 	if err != nil {
+// 		fmt.Println(err)
+// 	}
+// 	// defer Close()
+
+// }

--- a/interfaces/repository.go
+++ b/interfaces/repository.go
@@ -45,21 +45,16 @@ func (r *CommonRepository) Find(ctx context.Context) (schedule []*domain.Schedul
 	return
 }
 
-func (r *CommonRepository) DivideEvent(ctx context.Context) {
+func (r *CommonRepository) DivideEvent(ctx context.Context) (e *linebot.Event) {
+	fmt.Println("DivideEve")
 	event := r.Bot.CathEvents(ctx)
-	fmt.Println(event)
-	if event.Type == linebot.EventTypeMessage {
-		switch Message := event.Message.(type) {
-		case *linebot.TextMessage:
-			msg := Message.Text
-			r.Bot.CallBack(msg)
-		}
-	} else {
-		fmt.Println("だめです")
-	}
+	// r.Bot.Hoge(event) エラ〜起きる
+	fmt.Println("DivideEvent", event)
+
+	return
 }
 
-func (r *CommonRepository) ConversionReply(resp []*domain.Schedule) {
-	// 文字列に直す処理
-	// r.Bot.MsgReply(resp)
-}
+// func (r *CommonRepository) ConversionReply(resp []*domain.Schedule) {
+// 	// 文字列に直す処理
+// 	// r.Bot.MsgReply(resp)
+// }

--- a/interfaces/repository.go
+++ b/interfaces/repository.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 
 	"github.com/tmkshy1908/Portfolio/domain"
+	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/api"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/db"
 )
 
 type CommonRepository struct {
-	DB db.SqlHandler
+	DB  db.SqlHandler
+	Bot api.LineHandller
 }
 
 const (
@@ -42,11 +44,6 @@ func (r *CommonRepository) Find(ctx context.Context) (schedule []*domain.Schedul
 	return
 }
 
-// func (r *CommonRepository) Create(ctx context.Context) (schedule []*domain.Schedule, err error){
-// 	_, err = r.DB.Exec(ctx, INSERT_SCHEDULE)
-// 	if err != nil {
-// 		fmt.Println(err)
-// 	}
-// 	// defer Close()
-
-// }
+func (r *CommonRepository) Inform(ctx context.Context) {
+	r.Bot.CathEvents(ctx)
+}

--- a/interfaces/repository.go
+++ b/interfaces/repository.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 
 	"github.com/tmkshy1908/Portfolio/domain"
-	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/api"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/db"
+	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/line"
 )
 
 type CommonRepository struct {
 	DB  db.SqlHandler
-	Bot api.LineHandller
+	Bot line.LineClient
 }
 
 const (

--- a/pkg/infrastructure/api/line_api.go
+++ b/pkg/infrastructure/api/line_api.go
@@ -19,9 +19,8 @@ type LineConf struct {
 
 type LineHandller interface {
 	CathEvents(ctx context.Context) (e *linebot.Event)
-	CallBack(msg string)
-	StickerReply()
-	ImageReply()
+	MsgReply(msg string)
+	Hoge(event *linebot.Event) (e *linebot.Event)
 }
 
 func NewLineHandller() (lh LineHandller, err error) {
@@ -40,32 +39,54 @@ func NewLineHandller() (lh LineHandller, err error) {
 }
 
 func (bot *LineConf) CathEvents(ctx context.Context) (e *linebot.Event) {
+	fmt.Println("aaaaaaa")
+	// events, err := bot.Bot.ParseRequest(ctx.Value("request").(*http.Request))
+	// if err != nil {
+	// 	fmt.Println(err)
+	// } else {
+	// 	fmt.Println("CathEvents")
+	// }
+	// for _, event := range events {
+	// 	e = event
+	// }
+	// return
 	events, err := bot.Bot.ParseRequest(ctx.Value("request").(*http.Request))
 	if err != nil {
-		fmt.Println(err)
+		fmt.Println(err, "ParseReq")
 	} else {
 		fmt.Println("CathEvents")
 	}
 	for _, event := range events {
-		e = event
+		if event.Type == linebot.EventTypeMessage {
+			e = event
+		} else {
+			fmt.Println("EventTypeが違う")
+		}
 	}
 	return
 }
 
-func (bot *LineConf) CallBack(msg string) {
+func (bot *LineConf) MsgReply(msg string) {
 	replyMessage := linebot.NewTextMessage(msg)
 	bot.Bot.BroadcastMessage(replyMessage).Do()
 }
-func (bot *LineConf) StickerReply() {
-	result := "良いステッカーだね"
-	replyMessage := linebot.NewTextMessage(result)
-	bot.Bot.BroadcastMessage(replyMessage).Do()
-}
 
-func (bot *LineConf) ImageReply() {
-	result := "素敵な写真だね"
-	replyMessage := linebot.NewTextMessage(result)
-	bot.Bot.BroadcastMessage(replyMessage).Do()
+const (
+	stickerReply string = "いいスタンプだね！"
+	imageReply   string = "素敵な写真だね！"
+)
+
+func (bot *LineConf) Hoge(event *linebot.Event) (e *linebot.Event) {
+	switch event.Message.(type) {
+	case *linebot.TextMessage:
+		e = event
+	case *linebot.StickerMessage:
+		bot.MsgReply(stickerReply)
+
+	case *linebot.ImageMessage:
+		bot.MsgReply(imageReply)
+	}
+	return
 }
 
 // func (l *LineConf) CathEvents(c echo.Context) (e *linebot.Event) {

--- a/pkg/infrastructure/api/line_api.go
+++ b/pkg/infrastructure/api/line_api.go
@@ -20,7 +20,7 @@ type LineConf struct {
 type LineHandller interface {
 	CathEvents(ctx context.Context) (e *linebot.Event)
 	MsgReply(msg string)
-	Hoge(event *linebot.Event) (e *linebot.Event)
+	// Hoge(event *linebot.Event) (e *linebot.Event)
 }
 
 func NewLineHandller() (lh LineHandller, err error) {
@@ -39,26 +39,24 @@ func NewLineHandller() (lh LineHandller, err error) {
 }
 
 func (bot *LineConf) CathEvents(ctx context.Context) (e *linebot.Event) {
-	fmt.Println("aaaaaaa")
-	// events, err := bot.Bot.ParseRequest(ctx.Value("request").(*http.Request))
-	// if err != nil {
-	// 	fmt.Println(err)
-	// } else {
-	// 	fmt.Println("CathEvents")
-	// }
-	// for _, event := range events {
-	// 	e = event
-	// }
-	// return
 	events, err := bot.Bot.ParseRequest(ctx.Value("request").(*http.Request))
 	if err != nil {
-		fmt.Println(err, "ParseReq")
+		fmt.Println("ParseReq", err)
 	} else {
 		fmt.Println("CathEvents")
 	}
 	for _, event := range events {
 		if event.Type == linebot.EventTypeMessage {
 			e = event
+			switch event.Message.(type) {
+			case *linebot.TextMessage:
+				e = event
+			case *linebot.StickerMessage:
+				bot.MsgReply(stickerReply)
+
+			case *linebot.ImageMessage:
+				bot.MsgReply(imageReply)
+			}
 		} else {
 			fmt.Println("EventTypeが違う")
 		}
@@ -76,18 +74,18 @@ const (
 	imageReply   string = "素敵な写真だね！"
 )
 
-func (bot *LineConf) Hoge(event *linebot.Event) (e *linebot.Event) {
-	switch event.Message.(type) {
-	case *linebot.TextMessage:
-		e = event
-	case *linebot.StickerMessage:
-		bot.MsgReply(stickerReply)
+// func (bot *LineConf) Hoge(event *linebot.Event) (e *linebot.Event) {
+// 	switch event.Message.(type) {
+// 	case *linebot.TextMessage:
+// 		e = event
+// 	case *linebot.StickerMessage:
+// 		bot.MsgReply(stickerReply)
 
-	case *linebot.ImageMessage:
-		bot.MsgReply(imageReply)
-	}
-	return
-}
+// 	case *linebot.ImageMessage:
+// 		bot.MsgReply(imageReply)
+// 	}
+// 	return
+// }
 
 // func (l *LineConf) CathEvents(c echo.Context) (e *linebot.Event) {
 // 	events, err := linebot.ParseRequest(c.Request())

--- a/pkg/infrastructure/api/line_api.go
+++ b/pkg/infrastructure/api/line_api.go
@@ -18,7 +18,8 @@ type LineConf struct {
 }
 
 type LineHandller interface {
-	CathEvents(ctx context.Context)
+	CathEvents(ctx context.Context) (e *linebot.Event)
+	CallBack(msg string)
 	StickerReply()
 	ImageReply()
 }
@@ -38,7 +39,7 @@ func NewLineHandller() (lh LineHandller, err error) {
 	return
 }
 
-func (bot *LineConf) CathEvents(ctx context.Context) {
+func (bot *LineConf) CathEvents(ctx context.Context) (e *linebot.Event) {
 	events, err := bot.Bot.ParseRequest(ctx.Value("request").(*http.Request))
 	if err != nil {
 		fmt.Println(err)
@@ -46,13 +47,15 @@ func (bot *LineConf) CathEvents(ctx context.Context) {
 		fmt.Println("CathEvents")
 	}
 	for _, event := range events {
-		fmt.Println(event)
-		result := "テスト"
-		replyMessage := linebot.NewTextMessage(result)
-		bot.Bot.BroadcastMessage(replyMessage).Do()
+		e = event
 	}
+	return
 }
 
+func (bot *LineConf) CallBack(msg string) {
+	replyMessage := linebot.NewTextMessage(msg)
+	bot.Bot.BroadcastMessage(replyMessage).Do()
+}
 func (bot *LineConf) StickerReply() {
 	result := "良いステッカーだね"
 	replyMessage := linebot.NewTextMessage(result)

--- a/pkg/infrastructure/api/line_api.go
+++ b/pkg/infrastructure/api/line_api.go
@@ -18,7 +18,7 @@ type LineConf struct {
 }
 
 type LineHandller interface {
-	CathEvents(ctx context.Context) (e *linebot.Event)
+	CathEvents(ctx context.Context) (msg string)
 	MsgReply(msg string)
 	// Hoge(event *linebot.Event) (e *linebot.Event)
 }
@@ -38,7 +38,7 @@ func NewLineHandller() (lh LineHandller, err error) {
 	return
 }
 
-func (bot *LineConf) CathEvents(ctx context.Context) (e *linebot.Event) {
+func (bot *LineConf) CathEvents(ctx context.Context) (msg string) {
 	events, err := bot.Bot.ParseRequest(ctx.Value("request").(*http.Request))
 	if err != nil {
 		fmt.Println("ParseReq", err)
@@ -47,10 +47,11 @@ func (bot *LineConf) CathEvents(ctx context.Context) (e *linebot.Event) {
 	}
 	for _, event := range events {
 		if event.Type == linebot.EventTypeMessage {
-			e = event
-			switch event.Message.(type) {
+
+			switch message := event.Message.(type) {
 			case *linebot.TextMessage:
-				e = event
+				msg = message.Text
+
 			case *linebot.StickerMessage:
 				bot.MsgReply(stickerReply)
 

--- a/pkg/infrastructure/api/line_api.go
+++ b/pkg/infrastructure/api/line_api.go
@@ -20,7 +20,6 @@ type LineConf struct {
 type LineHandller interface {
 	CathEvents(ctx context.Context) (msg string)
 	MsgReply(msg string)
-	// Hoge(event *linebot.Event) (e *linebot.Event)
 }
 
 func NewLineHandller() (lh LineHandller, err error) {
@@ -65,42 +64,12 @@ func (bot *LineConf) CathEvents(ctx context.Context) (msg string) {
 	return
 }
 
-func (bot *LineConf) MsgReply(msg string) {
-	replyMessage := linebot.NewTextMessage(msg)
-	bot.Bot.BroadcastMessage(replyMessage).Do()
-}
-
 const (
 	stickerReply string = "いいスタンプだね！"
 	imageReply   string = "素敵な写真だね！"
 )
 
-// func (bot *LineConf) Hoge(event *linebot.Event) (e *linebot.Event) {
-// 	switch event.Message.(type) {
-// 	case *linebot.TextMessage:
-// 		e = event
-// 	case *linebot.StickerMessage:
-// 		bot.MsgReply(stickerReply)
-
-// 	case *linebot.ImageMessage:
-// 		bot.MsgReply(imageReply)
-// 	}
-// 	return
-// }
-
-// func (l *LineConf) CathEvents(c echo.Context) (e *linebot.Event) {
-// 	events, err := linebot.ParseRequest(c.Request())
-// 	if err != nil {
-// 		fmt.Println(err)
-// 	}
-// 	for _, event := range events {
-// 		if event.Type == linebot.EventTypeMessage {
-// 			switch message := event.Message.(type) {
-
-// 			case *linebot.TextMessage:
-// 				replyMessage := message.Text
-
-// 			}
-// 		}
-// 	}
-// }
+func (bot *LineConf) MsgReply(msg string) {
+	replyMessage := linebot.NewTextMessage(msg)
+	bot.Bot.BroadcastMessage(replyMessage).Do()
+}

--- a/pkg/infrastructure/api/line_api.go
+++ b/pkg/infrastructure/api/line_api.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/line/line-bot-sdk-go/linebot"
+)
+
+// type apiConnection struct {
+// 	ChannelSecrets string
+// 	AccessToken    string
+// }
+
+type LineConf struct {
+	Bot *linebot.Client
+}
+
+type LineHandller interface {
+	CathEvents(ctx context.Context)
+	StickerReply()
+	ImageReply()
+}
+
+func NewLineHandller() (lh LineHandller, err error) {
+	bot, err := linebot.New(
+		"4a7eaa800c243575a028db8438842246",
+		"P5L9UuMlMuG6sRbGgC0N/rGfICCAZ4P0ixLf7hgomVVyqxHvD5G4ZHNqu7IxpkpYut2LJ5NJ1qgKtCBveIIx4MZGOzuR6ldFGC33TBOXktYbHGhHY7bwQuolurMpN5YW/enP8ZNWUdBjE7PeqGEOswdB04t89/1O/w1cDnyilFU=",
+	)
+	if err != nil {
+		fmt.Println("linebot.Newエラー", err)
+	} else {
+		fmt.Println("Api Connected.")
+	}
+	lh = &LineConf{Bot: bot}
+
+	return
+}
+
+func (bot *LineConf) CathEvents(ctx context.Context) {
+	events, err := bot.Bot.ParseRequest(ctx.Value("request").(*http.Request))
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println("CathEvents")
+	}
+	for _, event := range events {
+		fmt.Println(event)
+		result := "テスト"
+		replyMessage := linebot.NewTextMessage(result)
+		bot.Bot.BroadcastMessage(replyMessage).Do()
+	}
+}
+
+func (bot *LineConf) StickerReply() {
+	result := "良いステッカーだね"
+	replyMessage := linebot.NewTextMessage(result)
+	bot.Bot.BroadcastMessage(replyMessage).Do()
+}
+
+func (bot *LineConf) ImageReply() {
+	result := "素敵な写真だね"
+	replyMessage := linebot.NewTextMessage(result)
+	bot.Bot.BroadcastMessage(replyMessage).Do()
+}
+
+// func (l *LineConf) CathEvents(c echo.Context) (e *linebot.Event) {
+// 	events, err := linebot.ParseRequest(c.Request())
+// 	if err != nil {
+// 		fmt.Println(err)
+// 	}
+// 	for _, event := range events {
+// 		if event.Type == linebot.EventTypeMessage {
+// 			switch message := event.Message.(type) {
+
+// 			case *linebot.TextMessage:
+// 				replyMessage := message.Text
+
+// 			}
+// 		}
+// 	}
+// }

--- a/pkg/infrastructure/db/postgres.go
+++ b/pkg/infrastructure/db/postgres.go
@@ -40,7 +40,7 @@ func NewHandler() (h SqlHandler, err error) {
 		fmt.Println(err)
 		return
 	} else {
-		fmt.Println("ok")
+		fmt.Println("DB Connected.")
 	}
 
 	h = &SqlConf{Conn: db}

--- a/pkg/infrastructure/db/postgres.go
+++ b/pkg/infrastructure/db/postgres.go
@@ -33,7 +33,7 @@ func NewHandler() (h SqlHandler, err error) {
 		Password: "1234",
 	}
 
-	connectionString := fmt.Sprintf("user=%s dbname=%s password=%s sslmode=disable", conf.User, conf.Database, conf.Password)
+	connectionString := fmt.Sprintf("user=%s dbname=%s password=%s sslmode=disable sslmode=disable", conf.User, conf.Database, conf.Password)
 
 	db, err := sql.Open("postgres", connectionString)
 	if err != nil {

--- a/pkg/infrastructure/line/line_api.go
+++ b/pkg/infrastructure/line/line_api.go
@@ -1,4 +1,4 @@
-package api
+package line
 
 import (
 	"context"
@@ -17,12 +17,12 @@ type LineConf struct {
 	Bot *linebot.Client
 }
 
-type LineHandller interface {
+type LineClient interface {
 	CathEvents(ctx context.Context) (msg string)
 	MsgReply(msg string)
 }
 
-func NewLineHandller() (lh LineHandller, err error) {
+func NewLineClient() (lh LineClient, err error) {
 	bot, err := linebot.New(
 		"4a7eaa800c243575a028db8438842246",
 		"P5L9UuMlMuG6sRbGgC0N/rGfICCAZ4P0ixLf7hgomVVyqxHvD5G4ZHNqu7IxpkpYut2LJ5NJ1qgKtCBveIIx4MZGOzuR6ldFGC33TBOXktYbHGhHY7bwQuolurMpN5YW/enP8ZNWUdBjE7PeqGEOswdB04t89/1O/w1cDnyilFU=",

--- a/pkg/infrastructure/line/line_api.go
+++ b/pkg/infrastructure/line/line_api.go
@@ -22,7 +22,7 @@ type LineClient interface {
 	MsgReply(msg string)
 }
 
-func NewLineClient() (lh LineClient, err error) {
+func NewClient() (lh LineClient, err error) {
 	bot, err := linebot.New(
 		"4a7eaa800c243575a028db8438842246",
 		"P5L9UuMlMuG6sRbGgC0N/rGfICCAZ4P0ixLf7hgomVVyqxHvD5G4ZHNqu7IxpkpYut2LJ5NJ1qgKtCBveIIx4MZGOzuR6ldFGC33TBOXktYbHGhHY7bwQuolurMpN5YW/enP8ZNWUdBjE7PeqGEOswdB04t89/1O/w1cDnyilFU=",

--- a/pkg/infrastructure/router.go
+++ b/pkg/infrastructure/router.go
@@ -6,6 +6,6 @@ import (
 
 func NewRouter(controller *ControllHandler) {
 	http.HandleFunc("/hello", controller.CommonController.Sayhello)
-	http.HandleFunc("/sample", controller.CommonController.SampleHandler)
+	// http.HandleFunc("/sample", controller.CommonController.SampleHandler)
 	http.HandleFunc("/line", controller.CommonController.LineHandller)
 }

--- a/pkg/infrastructure/router.go
+++ b/pkg/infrastructure/router.go
@@ -7,6 +7,6 @@ import (
 
 func NewRouter(controller *ControllHandler) {
 	fmt.Println("NewRouter")
-	http.HandleFunc("/", controller.CommonController.Sayhello)
+	http.HandleFunc("/hello", controller.CommonController.Sayhello)
 	http.HandleFunc("/sample", controller.CommonController.SampleHandler)
 }

--- a/pkg/infrastructure/router.go
+++ b/pkg/infrastructure/router.go
@@ -1,12 +1,11 @@
 package infrastructure
 
 import (
-	"fmt"
 	"net/http"
 )
 
 func NewRouter(controller *ControllHandler) {
-	fmt.Println("NewRouter")
 	http.HandleFunc("/hello", controller.CommonController.Sayhello)
 	http.HandleFunc("/sample", controller.CommonController.SampleHandler)
+	http.HandleFunc("/line", controller.CommonController.LineHandller)
 }

--- a/pkg/infrastructure/server.go
+++ b/pkg/infrastructure/server.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/tmkshy1908/Portfolio/interfaces"
-	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/api"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/db"
+	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/line"
 )
 
 type ControllHandler struct {
@@ -14,7 +14,7 @@ type ControllHandler struct {
 	// 実態にアクセスするために*を使う
 }
 
-func NewServer(h db.SqlHandler, b api.LineHandller) {
+func NewServer(h db.SqlHandler, b line.LineClient) {
 	c := &ControllHandler{
 		CommonController: interfaces.NewController(h, b),
 	}

--- a/pkg/infrastructure/server.go
+++ b/pkg/infrastructure/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/tmkshy1908/Portfolio/interfaces"
+	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/api"
 	"github.com/tmkshy1908/Portfolio/pkg/infrastructure/db"
 )
 
@@ -13,9 +14,9 @@ type ControllHandler struct {
 	// 実態にアクセスするために*を使う
 }
 
-func NewServer(h db.SqlHandler) {
+func NewServer(h db.SqlHandler, b api.LineHandller) {
 	c := &ControllHandler{
-		CommonController: interfaces.NewController(h),
+		CommonController: interfaces.NewController(h, b),
 	}
 
 	NewRouter(c)
@@ -23,5 +24,7 @@ func NewServer(h db.SqlHandler) {
 	if err != nil {
 		fmt.Println(err)
 		return
+	} else {
+		fmt.Println("serverOK")
 	}
 }

--- a/usecase/interractor.go
+++ b/usecase/interractor.go
@@ -3,10 +3,11 @@ package usecase
 import (
 	"context"
 
+	"github.com/line/line-bot-sdk-go/linebot"
 	"github.com/tmkshy1908/Portfolio/domain"
 )
 
 type CommonRepository interface {
 	Find(ctx context.Context) (resp []*domain.Schedule, err error)
-	DivideEvent(ctx context.Context)
+	DivideEvent(ctx context.Context) (e *linebot.Event)
 }

--- a/usecase/interractor.go
+++ b/usecase/interractor.go
@@ -9,4 +9,5 @@ import (
 type CommonRepository interface {
 	Find(ctx context.Context) (resp []*domain.Schedule, err error)
 	DivideEvent(ctx context.Context) (msg string)
+	CallReply(msg string)
 }

--- a/usecase/interractor.go
+++ b/usecase/interractor.go
@@ -3,11 +3,10 @@ package usecase
 import (
 	"context"
 
-	"github.com/line/line-bot-sdk-go/linebot"
 	"github.com/tmkshy1908/Portfolio/domain"
 )
 
 type CommonRepository interface {
 	Find(ctx context.Context) (resp []*domain.Schedule, err error)
-	DivideEvent(ctx context.Context) (e *linebot.Event)
+	DivideEvent(ctx context.Context) (msg string)
 }

--- a/usecase/interractor.go
+++ b/usecase/interractor.go
@@ -8,5 +8,5 @@ import (
 
 type CommonRepository interface {
 	Find(ctx context.Context) (resp []*domain.Schedule, err error)
-	Inform(ctx context.Context)
+	DivideEvent(ctx context.Context)
 }

--- a/usecase/interractor.go
+++ b/usecase/interractor.go
@@ -8,4 +8,5 @@ import (
 
 type CommonRepository interface {
 	Find(ctx context.Context) (resp []*domain.Schedule, err error)
+	Inform(ctx context.Context)
 }

--- a/usecase/usecase.go
+++ b/usecase/usecase.go
@@ -20,3 +20,7 @@ func (i *CommonInteractor) UseCaseSampleRepository(ctx context.Context) (resp []
 
 	return
 }
+
+func (i *CommonInteractor) UseCaseLineRepository(ctx context.Context) {
+	i.CommonRepository.Inform(ctx)
+}

--- a/usecase/usecase.go
+++ b/usecase/usecase.go
@@ -15,7 +15,8 @@ func (i *CommonInteractor) UseCaseSampleRepository(ctx context.Context) (resp []
 	// event := i.CommonRepository.DivideEvent(ctx)
 	// msg := event.Message
 	// fmt.Println(msg, "msgだよ")
-
+	msg := i.CommonRepository.DivideEvent(ctx)
+	fmt.Println(msg, "Usecase")
 	resp, err = i.CommonRepository.Find(ctx)
 	if err != nil {
 		fmt.Println(err)
@@ -25,10 +26,10 @@ func (i *CommonInteractor) UseCaseSampleRepository(ctx context.Context) (resp []
 	return
 }
 
-func (i *CommonInteractor) UseCaseLineRepository(ctx context.Context) {
-	fmt.Println("LineRep")
-	i.CommonRepository.DivideEvent(ctx)
-	// event := i.CommonRepository.DivideEvent(ctx)
-	// msg := event.Message
-	// fmt.Println(msg, "msgだよ")
-}
+// func (i *CommonInteractor) UseCaseLineRepository(ctx context.Context) {
+// 	fmt.Println("LineRep")
+// i.CommonRepository.DivideEvent(ctx)
+// event := i.CommonRepository.DivideEvent(ctx)
+// msg := event.Message
+// fmt.Println(msg, "msgだよ")
+// }

--- a/usecase/usecase.go
+++ b/usecase/usecase.go
@@ -12,6 +12,10 @@ type CommonInteractor struct {
 }
 
 func (i *CommonInteractor) UseCaseSampleRepository(ctx context.Context) (resp []*domain.Schedule, err error) {
+	// event := i.CommonRepository.DivideEvent(ctx)
+	// msg := event.Message
+	// fmt.Println(msg, "msgだよ")
+
 	resp, err = i.CommonRepository.Find(ctx)
 	if err != nil {
 		fmt.Println(err)
@@ -22,5 +26,9 @@ func (i *CommonInteractor) UseCaseSampleRepository(ctx context.Context) (resp []
 }
 
 func (i *CommonInteractor) UseCaseLineRepository(ctx context.Context) {
+	fmt.Println("LineRep")
 	i.CommonRepository.DivideEvent(ctx)
+	// event := i.CommonRepository.DivideEvent(ctx)
+	// msg := event.Message
+	// fmt.Println(msg, "msgだよ")
 }

--- a/usecase/usecase.go
+++ b/usecase/usecase.go
@@ -2,7 +2,9 @@ package usecase
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/tmkshy1908/Portfolio/domain"
 )
@@ -12,15 +14,21 @@ type CommonInteractor struct {
 }
 
 func (i *CommonInteractor) UseCaseSampleRepository(ctx context.Context) (resp []*domain.Schedule, err error) {
-	// event := i.CommonRepository.DivideEvent(ctx)
-	// msg := event.Message
-	// fmt.Println(msg, "msgだよ")
 	msg := i.CommonRepository.DivideEvent(ctx)
 	fmt.Println(msg, "Usecase")
-	resp, err = i.CommonRepository.Find(ctx)
-	if err != nil {
-		fmt.Println(err)
-		return
+	if strings.Contains(msg, "取得") {
+		i.CommonRepository.CallReply(msg)
+		resp, err = i.CommonRepository.Find(ctx)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		a := &resp
+		out, err := json.Marshal(a)
+		if err != nil {
+			fmt.Println("marshal err")
+		}
+		i.CommonRepository.CallReply(string(out))
 	}
 
 	return

--- a/usecase/usecase.go
+++ b/usecase/usecase.go
@@ -5,20 +5,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/tmkshy1908/Portfolio/domain"
 )
 
 type CommonInteractor struct {
 	CommonRepository CommonRepository
 }
 
-func (i *CommonInteractor) UseCaseSampleRepository(ctx context.Context) (resp []*domain.Schedule, err error) {
+func (i *CommonInteractor) DivideMessage(ctx context.Context) {
 	msg := i.CommonRepository.DivideEvent(ctx)
-	fmt.Println(msg, "Usecase")
 	if strings.Contains(msg, "取得") {
 		i.CommonRepository.CallReply(msg)
-		resp, err = i.CommonRepository.Find(ctx)
+		resp, err := i.CommonRepository.Find(ctx)
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -33,11 +30,3 @@ func (i *CommonInteractor) UseCaseSampleRepository(ctx context.Context) (resp []
 
 	return
 }
-
-// func (i *CommonInteractor) UseCaseLineRepository(ctx context.Context) {
-// 	fmt.Println("LineRep")
-// i.CommonRepository.DivideEvent(ctx)
-// event := i.CommonRepository.DivideEvent(ctx)
-// msg := event.Message
-// fmt.Println(msg, "msgだよ")
-// }

--- a/usecase/usecase.go
+++ b/usecase/usecase.go
@@ -22,5 +22,5 @@ func (i *CommonInteractor) UseCaseSampleRepository(ctx context.Context) (resp []
 }
 
 func (i *CommonInteractor) UseCaseLineRepository(ctx context.Context) {
-	i.CommonRepository.Inform(ctx)
+	i.CommonRepository.DivideEvent(ctx)
 }


### PR DESCRIPTION
#概要
*https://github.com/tmkshy1908/Portfolio/issues/1

#変更点
・infrastructure/api/line_api.goの追加
・infrastructure/api/line_api.goにLineBotの設定と、Lineからのメッセージの取得と返信処理の追加
・LineHandllerの追加
・interfaces/repository.goにusecaseとline_apiを繋ぐ為の処理を追加
・usecase/usecase.goに文章に対しての分岐処理の追加


#課題
lineからメッセージを受け取って、メッセージの内容に対して特定の処理を返す事まで出来ましたが、
まだ（取得）、スタンプ、写真、に対しての処理しか実装出来ていない為これから実装します。
またUseCaseSampleRepository内で構造体の値をjsonに変換していますが、この処理もここでやるべきでないと思うので修正します。
https://github.com/tmkshy1908/Portfolio/blob/eb421d253823dc5d81c486ba6a244e3a85ed7bdf/usecase/usecase.go#L27


#レビューで見てほしいポイント
オニオンアーキテクチャを考慮した処理の流れとして正しいか、各層に対して書くべき処理は間違っていないか
ここにこの処理を書くべきでないなどあったらご指摘お願いします。
それと構造体の値をjsonに変換したいのですがその処理をどの層ですれば良いか教えてください。